### PR TITLE
made the naming for commands parameter more consistent

### DIFF
--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -27,14 +27,14 @@ struct ResolutionSettings {
 }
 
 // Spawns the camera that draws UI
-fn setup_camera(mut cmd: Commands) {
-    cmd.spawn(Camera2dBundle::default());
+fn setup_camera(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
 }
 
 // Spawns the UI
-fn setup_ui(mut cmd: Commands) {
+fn setup_ui(mut commands: Commands) {
     // Node that fills entire background
-    cmd.spawn(NodeBundle {
+    commands.spawn(NodeBundle {
         style: Style {
             width: Val::Percent(100.),
             ..default()


### PR DESCRIPTION
# Objective

Make the naming of a parameter more consistent.

## Solution

- Changing the name of a parameter.

## Testing

These changes can't be tested as they are documentation based.

---

I apologize if something is wrong here, this is my first PR to bevy.
